### PR TITLE
add macro-case for C #define macros; add run-tests

### DIFF
--- a/run-kebab-tests.lisp
+++ b/run-kebab-tests.lisp
@@ -1,0 +1,6 @@
+(load "~/quicklisp/setup.lisp")
+(ql:quickload :alexandria)
+(ql:quickload :split-sequence)
+(ql:quickload :prove)
+(load "src/kebab.lisp")
+(load "t/kebab.lisp")

--- a/src/kebab.lisp
+++ b/src/kebab.lisp
@@ -8,6 +8,7 @@
            :to-snake-case
            :to-pascal-case
            :to-kebab-case
+           :to-macro-case
            :to-lisp-case))
 
 (in-package :kebab)
@@ -106,5 +107,6 @@
 (define-converter camel-case  #'string-downcase #'string-capitalize "")
 (define-converter snake-case #'string-downcase #'string-downcase "_")
 (define-converter kebab-case #'string-downcase #'string-downcase "-")
+(define-converter macro-case #'string-upcase #'string-upcase "_")
 (define-converter lisp-case #'string-downcase #'string-downcase "-")
 

--- a/t/kebab.lisp
+++ b/t/kebab.lisp
@@ -55,7 +55,7 @@
                   (is (to-pascal-case '|lisp-case|) '|LispCase|)
                   (is (to-pascal-case '|com plexSt_-ring|) '|ComPlexStRing|)))
 
-(subtest "Test snakel_case"
+(subtest "Test snake_case"
          (subtest "Test on string"
                   (is (to-snake-case "PascalCase") "pascal_case")
                   (is (to-snake-case "camelCase") "camel_case")
@@ -100,6 +100,29 @@
                   (is (to-kebab-case '|kebab-case|) '|kebab-case|)
                   (is (to-kebab-case '|lisp-case|) '|lisp-case|)
                   (is (to-kebab-case '|com plexSt_-ring|) '|com-plex-st-ring|)))
+
+(subtest "Test macro-case"
+         (subtest "Test on string"
+                  (is (to-macro-case "PascalCase") "PASCAL_CASE")
+                  (is (to-macro-case "camelCase") "CAMEL_CASE")
+                  (is (to-macro-case "snake_case") "SNAKE_CASE")
+                  (is (to-macro-case "kebab-case") "KEBAB_CASE")
+                  (is (to-macro-case "lisp-case") "LISP_CASE")
+                  (is (to-macro-case "com plexSt_-ring") "COM_PLEX_ST_RING"))
+         (subtest "Test on keyword"
+                  (is (to-macro-case :|PascalCase|) :PASCAL_CASE)
+                  (is (to-macro-case :|camelCase|) :CAMEL_CASE)
+                  (is (to-macro-case :|snake_case|) :SNAKE_CASE)
+                  (is (to-macro-case :|kebab-case|) :KEBAB_CASE)
+                  (is (to-macro-case :|lisp-case|) :LISP_CASE)
+                  (is (to-macro-case :|com plexSt_-ring|) :COM_PLEX_ST_RING))
+         (subtest "Test on symbol"
+                  (is (to-macro-case '|PascalCase|) 'PASCAL_CASE)
+                  (is (to-macro-case '|camelCase|) 'CAMEL_CASE)
+                  (is (to-macro-case '|snake_case|) 'SNAKE_CASE)
+                  (is (to-macro-case '|kebab-case|) 'KEBAB_CASE)
+                  (is (to-macro-case '|lisp-case|) 'LISP_CASE)
+                  (is (to-macro-case '|com plexSt_-ring|) 'COM_PLEX_ST_RING)))
 
 (subtest "Test lisp-case"
          (subtest "Test on string"


### PR DESCRIPTION
added a simple "run-tests" that can be loaded into a repl
added a "macro-case" function for generating upper-case snake-case for old-style pound-define macros in C
